### PR TITLE
Add build badge from travis-ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # corretto-8-docker
+
+[![Build Status](https://travis-ci.org/corretto/corretto-8-docker.svg?branch=master)](https://travis-ci.org/corretto/corretto-8-docker)
+
 Master repository where Dockerfiles for [Corretto 8](https://aws.amazon.com/corretto/) are hosted.
 For usage instructions, see the [AWS documentation site](https://docs.aws.amazon.com/corretto/latest/corretto-8-ug/docker-install.html).
 


### PR DESCRIPTION
Here's the latest build: https://travis-ci.org/corretto/corretto-8-docker/jobs/456207071

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
