### PR TITLE
update yum repo when build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN set -eux \
     && grep -q '^gpgcheck=1' /etc/yum.repos.d/corretto.repo \
     && yum install -y java-1.8.0-amazon-corretto-devel-$version \
     && yum install -y fontconfig \
+    && yum update -y \
     && yum clean all
 
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-amazon-corretto


### PR DESCRIPTION
*Issue #, if available:*
#57 

*Description of changes:*
Update installed packages. it guarantees that we won't derive outdated packages from base images. 
We did it before yum clean, so the whole yum cache wipe out before the docker image is finalized.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
