### PR TITLE
Delete openjdk8 sources after install corretto rpm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,9 @@ RUN set -eux \
     && curl -fL -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo \
     && grep -q '^gpgcheck=1' /etc/yum.repos.d/corretto.repo \
     && yum install -y java-1.8.0-amazon-corretto-devel-$version \
+    && (find /usr/lib/jvm/java-1.8.0-amazon-corretto -name src.zip -delete || true) \
     && yum install -y fontconfig \
     && yum clean all
+
 
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-amazon-corretto


### PR DESCRIPTION
*Issue #, if available:*
corretto-8 [issue-229](https://github.com/corretto/corretto-8/issues/229)

*Description of changes:*
try to delete src.zip(50M) right after rpm installation.

src.zip is the source code or JRE. they are mainly used when developers browse JRE classes in IDEs. I don't think it's very useful in docker environment.


*Result*
The docker size reduces about 50M.

amazoncorretto8-after                                             latest              0783bb8b366f        9 minutes ago       337MB
amazoncorretto8-before                                            latest              fa62bda23bd1        28 minutes ago      389MB

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
