### PR TITLE
Update Corretto8 Docker image to 8.252.09.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2
 
-ARG version=1.8.0_242.b08-1
+ARG version=1.8.0_252.b09-1
 # In addition to installing the Amazon corretto, we also install
 # fontconfig. The folks who manage the docker hub's
 # official image library have found that font management


### PR DESCRIPTION
*Issue #, if available:*
Update Corretto8 Docker image to 8.252.09.1
*Description of changes:*
This change updates the Vorretto8 to latest version i.e., 8.252.09.1


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
