### PR TITLE
[REDO] switch default locale to utf8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,6 @@ RUN set -eux \
     && yum install -y fontconfig \
     && yum clean all
 
+ENV LANG C.UTF-8
 
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-amazon-corretto

--- a/contrib/debian/Dockerfile
+++ b/contrib/debian/Dockerfile
@@ -51,4 +51,6 @@ RUN set -eux; \
 	rm -rf $GNUPGHOME corretto.asc $deb; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false curl dirmngr gnupg
 
+ENV LANG C.UTF-8
+
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-amazon-corretto

--- a/test-image.yaml
+++ b/test-image.yaml
@@ -1,5 +1,10 @@
 schemaVersion: "2.0.0"
 
+metadataTest:
+  env:
+    - key: LANG
+      value: C.UTF-8
+
 commandTests:
   - name: "java command is registered using alternatives."
     command: "java"


### PR DESCRIPTION
*Issue #, if available:*
Customers of corretto-8-docker  may observe encoding issues if they use non-ASCII encodings in their java applications. Their applications run well in conventional Linux environments but start failing after they migrate to our docker environments.

Our Corretto docker images are based on amazonlinux. Therefore, we derive a lot from it. The root cause is amazonlinux docker image doesn't set LANG. Unlike general-purposed linux distros, the amazonlinux image prefer to provide a raw/minimal Linux.

Here is the raw locale of amazonlinux2 image:

> docker run -it --rm amazonlinux:latest sh -c "locale"
> LANG=
> LC_CTYPE="POSIX"
> LC_NUMERIC="POSIX"
> LC_TIME="POSIX"
> LC_COLLATE="POSIX"
> LC_MONETARY="POSIX"
> LC_MESSAGES="POSIX"
> LC_PAPER="POSIX"
> LC_NAME="POSIX"
> LC_ADDRESS="POSIX"
> LC_TELEPHONE="POSIX"
> LC_MEASUREMENT="POSIX"
> LC_IDENTIFICATION="POSIX"
> LC_ALL=

The POSIX locale is the key to keep amazonlinux2 image slim. We shouldn't break it. On the other side, Corretto docker images should provide our customers JAVA application runtime.  Generally speaking, Java applications run on systems with Unicode charset support. Almost all Java developers assume their targeting Linux environments using utf-8 encoding. We should avoid unexpected behaviors for our customers.

*Description of changes:*
This is a REDO of PR #24.  Thanks you!  @smelchior

set LANG to C.UTF-8 

After merging this PR, the locale will look as follows:
> docker run -it --rm amazon-corretto-8  sh -c "locale"
> LANG=C.UTF-8
> LC_CTYPE="C.UTF-8"
> LC_NUMERIC="C.UTF-8"
> LC_TIME="C.UTF-8"
> LC_COLLATE="C.UTF-8"
> LC_MONETARY="C.UTF-8"
> LC_MESSAGES="C.UTF-8"
> LC_PAPER="C.UTF-8"
> LC_NAME="C.UTF-8"
> LC_ADDRESS="C.UTF-8"
> LC_TELEPHONE="C.UTF-8"
> LC_MEASUREMENT="C.UTF-8"
> LC_IDENTIFICATION="C.UTF-8"
> LC_ALL=

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
